### PR TITLE
Add display name with proper capitalization and add new carrier Purolator.

### DIFF
--- a/tracking_url/__init__.py
+++ b/tracking_url/__init__.py
@@ -13,33 +13,46 @@ def guess_carrier(tracking_number):
 
 
 class TrackingPattern:
-    def __init__(self, carrier, url_pattern, number_patterns):
+    def __init__(self, carrier, carrier_display, url_pattern, number_patterns):
         self.carrier = carrier
+        self.carrier_display = carrier_display
         self.url_pattern = url_pattern
         self.number_patterns = [re.compile(number_pattern) for number_pattern in number_patterns]
 
     def match(self, number):
         for number_pattern in self.number_patterns:
             if number_pattern.fullmatch(number):
-                return TrackingUrl(self.url_pattern.format(tracking_number=number), self.carrier, number)
+                return TrackingUrl(self.url_pattern.format(tracking_number=number),
+                                   self.carrier, self.carrier_display, number)
 
 
 class TrackingUrl:
-    def __init__(self, url, carrier, number):
+    def __init__(self, url, carrier, carrier_display, number):
         self.url = url
         self.carrier = carrier
+        self.carrier_display = carrier_display
         self.number = number
 
 
 TRACKING_PATTERNS = [
     TrackingPattern(
+        'purolator',
+        'Purolator',
+        'https://www.purolator.com/en/shipping/tracker?pin={tracking_number}',
+        [
+            r'33\d{10}',
+            r'[A-Z]{3}\d{9}',
+        ]),
+    TrackingPattern(
         'ups',
-        'http://wwwapps.ups.com/WebTracking/track?track=yes&trackNums={tracking_number}',
+        'UPS',
+        'https://wwwapps.ups.com/WebTracking/track?track=yes&trackNums={tracking_number}',
         [
             r'1Z[0-9A-Z]{16}|[\dT]\d{10}'
         ]),
     TrackingPattern(
         'fedex',
+        'Fedex',
         'https://www.fedex.com/apps/fedextrack/?tracknumbers={tracking_number}',
         [
             r'96\d{20}',
@@ -50,6 +63,7 @@ TRACKING_PATTERNS = [
         ]),
     TrackingPattern(
         'usps',
+        'USPS',
         'https://tools.usps.com/go/TrackConfirmAction?qtc_tLabels1={tracking_number}',
         [
             r'91\d+',
@@ -63,6 +77,7 @@ TRACKING_PATTERNS = [
     ),
     TrackingPattern(
         'chronopost',
+        'Chronopost',
         'https://www.chronopost.fr/tracking-no-cms/suivi-page?listeNumerosLT={tracking_number}',
         [
             r'[A-Za-z]{2}\d{9}[A-Za-z]{2}',
@@ -72,7 +87,8 @@ TRACKING_PATTERNS = [
     ),
     TrackingPattern(
         'dhl',
-        'http://www.dhl.com/en/express/tracking.html?AWB={tracking_number}&brand=DHL',
+        'DHL',
+        'https://www.dhl.com/en/express/tracking.html?AWB={tracking_number}&brand=DHL',
         [
             r'\d{10,11}'
         ])

--- a/tracking_url/__init__.py
+++ b/tracking_url/__init__.py
@@ -90,8 +90,8 @@ TRACKING_PATTERNS = [
         'DHL',
         'https://www.dhl.com/en/express/tracking.html?AWB={tracking_number}&brand=DHL',
         [
-            r'JD{18}',
-            r'JJD{13}',
+            r'JD\d{18}',
+            r'JJD\d{13}',
             r'\d{10,11}'
         ])
 ]

--- a/tracking_url/__init__.py
+++ b/tracking_url/__init__.py
@@ -90,6 +90,8 @@ TRACKING_PATTERNS = [
         'DHL',
         'https://www.dhl.com/en/express/tracking.html?AWB={tracking_number}&brand=DHL',
         [
+            r'JD{18}',
+            r'JJD{13}',
             r'\d{10,11}'
         ])
 ]

--- a/tracking_url/tests/test_tracking_url.py
+++ b/tracking_url/tests/test_tracking_url.py
@@ -85,3 +85,21 @@ class GuessCarrierTestCase(TestCase):
         self.check_carrier('dhl', [
             '8564385550'
         ])
+
+    def test_purolator(self):
+        # from: https://www.trackingmore.com/tracking-status-detail-en-254.html
+        self.check_carrier('purolator', [
+            '332359073811',
+            '331426749957',
+            'KYV009956937',
+            'CGK002986959',
+            '331434972567',
+            '331435738942',
+            'JFV247545960',
+            'JFV247698458',
+            '331434463120',
+            '331432270063',
+            '331433946802',
+            'TLR000083964',
+            '331432012770',
+        ])


### PR DESCRIPTION
Hello,

My company recently added this package to help us manage tracking information on order shipments. I added support for specifying a `carrier_display` value with the proper capitalization for the company. I also added a new carrier, Purolator that we use for shipments in Canada. I have also added testing for the new carrier and a comment with the link where I found test tracking ids.

Please let me know if there is anything else you would like from me for this pull request.
Thank you,

Carlos Velez